### PR TITLE
Do not uninstall python-openvswitch in Newton+

### DIFF
--- a/image-patching/stopgap-script/nuage_overcloud_full_patch.sh
+++ b/image-patching/stopgap-script/nuage_overcloud_full_patch.sh
@@ -135,7 +135,11 @@ rm -f rhel_unsubscribe
 #####
 
 function uninstall_packages {
-virt-customize --run-command 'yum remove python-openvswitch -y' -a $1 --memsize $VIRT_CUSTOMIZE_MEMSIZE --selinux-relabel --edit '/usr/lib/systemd/system/rhel-autorelabel.service: $_ = "" if /StandardInput=tty/'
+# For Newton and above, use standard python-openvswitch
+if [ $2 -le 9 ]; then
+  virt-customize --run-command 'yum remove python-openvswitch -y' -a $1 --memsize $VIRT_CUSTOMIZE_MEMSIZE --selinux-relabel --edit '/usr/lib/systemd/system/rhel-autorelabel.service: $_ = "" if /StandardInput=tty/'
+fi
+
 virt-customize --run-command 'yum remove openvswitch -y' -a $1 --memsize $VIRT_CUSTOMIZE_MEMSIZE --selinux-relabel --edit '/usr/lib/systemd/system/rhel-autorelabel.service: $_ = "" if /StandardInput=tty/'
 
 }
@@ -263,7 +267,7 @@ if [ "$CONTINUE_SCRIPT" = true ]; then
 
     echo "Uninstalling packages"
 
-    uninstall_packages $ImageName
+    uninstall_packages $ImageName $Version
 
     echo "Creating Repo File"
 

--- a/image-patching/stopgap-script/nuage_overcloud_full_patch_cbis.sh
+++ b/image-patching/stopgap-script/nuage_overcloud_full_patch_cbis.sh
@@ -85,7 +85,12 @@ fi
 #####
 
 function uninstall_packages {
-virt-customize --run-command 'yum remove python-openvswitch -y' -a $1 --memsize $VIRT_CUSTOMIZE_MEMSIZE --selinux-relabel --edit '/usr/lib/systemd/system/rhel-autorelabel.service: $_ = "" if /StandardInput=tty/'
+
+# For Newton and above, use standard python-openvswitch
+if [ $2 -le 9 ]; then
+  virt-customize --run-command 'yum remove python-openvswitch -y' -a $1 --memsize $VIRT_CUSTOMIZE_MEMSIZE --selinux-relabel --edit '/usr/lib/systemd/system/rhel-autorelabel.service: $_ = "" if /StandardInput=tty/'
+fi
+
 virt-customize --run-command 'yum remove openvswitch -y' -a $1 --memsize $VIRT_CUSTOMIZE_MEMSIZE --selinux-relabel --edit '/usr/lib/systemd/system/rhel-autorelabel.service: $_ = "" if /StandardInput=tty/'
 
 }
@@ -199,7 +204,7 @@ if [ "$CONTINUE_SCRIPT" = true ]; then
 
     echo "Uninstalling packages"
 
-    uninstall_packages $ImageName
+    uninstall_packages $ImageName $Version
 
     echo "Creating Repo File"
 


### PR DESCRIPTION
In Newton and above, python-openvswitch is required on overcloud-full image.