### PR TITLE
Fix SSL verification error introduced in Python update

### DIFF
--- a/generate-cms-id/restproxy.py
+++ b/generate-cms-id/restproxy.py
@@ -6,6 +6,7 @@ import httplib
 import json
 import logging
 import socket
+import ssl
 import time
 
 LOG = logging.getLogger(__name__)
@@ -93,8 +94,17 @@ class RESTProxyServer(object):
         LOG.debug('Request body: %s', body)
 
         if self.serverssl:
-            conn = httplib.HTTPSConnection(
-                self.server, self.port, timeout=self.timeout)
+            if hasattr(ssl, '_create_unverified_context'):
+                # pylint: disable=no-member
+                # pylint: disable=unexpected-keyword-arg
+                conn = httplib.HTTPSConnection(
+                    self.server, self.port, timeout=self.timeout,
+                    context=ssl._create_unverified_context())
+                # pylint: enable=no-member
+                # pylint: enable=unexpected-keyword-arg
+            else:
+                conn = httplib.HTTPSConnection(
+                    self.server, self.port, timeout=self.timeout)
             if conn is None:
                 LOG.error('RESTProxy: Could not establish HTTPS '
                           'connection')


### PR DESCRIPTION
In Python 2.7.9 and 3.4.3, Python started verifying SSL certificates. This broke code whenever `httplib.HTTPSClient` was used. This can be fixed by using an `ssl.Context` object stating that no verification is needed. For more info, see https://access.redhat.com/articles/2039753.

Note: this commit is compatible with older versions of Python which don't have the `ssl.Context` class.