### PR TITLE
Added documentation to nuage_overcloud_full_patch.py

### DIFF
--- a/image-patching/stopgap-script/nuage_overcloud_full_patch.py
+++ b/image-patching/stopgap-script/nuage_overcloud_full_patch.py
@@ -13,7 +13,8 @@ from logging import handlers
 # RhelPassword: Password for the RHEL subscription
 # RhelPool    : RHEL Pool to subscribe
 # RepoName    : Name of the local repository
-# RepoBaseUrl : Base URL of the local repository
+# RepoBaseUrl : URL to the repository for VRS packages to be installed
+# AVRSBaseUrl : URL to the repository for AVRS packages to be downloaded
 # Version     : Version of OSP Director 13
 #
 # The following sequence is executed by the script
@@ -94,7 +95,8 @@ def show_help():
     cmds_run(['echo " --RhelPassword=Password for the RHEL Subscription"'])
     cmds_run(['echo " --RhelPool=Pool to subscribe to for base packages"'])
     cmds_run(['echo " --RepoName=Name for the local repo hosting the Nuage RPMs"'])
-    cmds_run(['echo " --RepoBaseUrl=Base URL for the repo hosting the Nuage RPMs"'])
+    cmds_run(['echo " --RepoBaseUrl=Base URL for the repo hosting the Nuage VRS RPMs"'])
+    cmds_run(['echo " --AVRSBaseUrl=Base URL for the repo hosting the Nuage AVRS RPMs"'])
     cmds_run(['echo " --Version=OSP-Director version (10)"'])
     cmds_run(['echo " -h or --help: Show this message"'])
 


### PR DESCRIPTION
There is a function called copy_avrs_packages when the command line option AVRSBaseUrl is encounter. Added documentation for this command line function, and modified documentation for RepoBaseUrl function to be more consistent.