### PR TITLE
fixing: OPENSTACK-2620/2650 & PROD-10354/10408/10432

### DIFF
--- a/image-patching/stopgap-script/README.md
+++ b/image-patching/stopgap-script/README.md
@@ -1,6 +1,6 @@
-Steps:
+#Steps:
 
-Clone this repo onto the machine that is accessible to the nuage-rpms repo and make sure the machine also has `libguestfs-tools` installed.
+Clone this repo onto the machine that is accessible to the nuage-rpms repo and make sure the machine also has `libguestfs-tools` and `libguestfs-tools-c` are installed.
 
 ```
 yum install libguestfs-tools -y
@@ -10,46 +10,334 @@ git checkout OSPD13_VRS_offload
 cd image-patching/stopgap-script/
 ```
 
-Copy the overcloud-full.qcow2 from undercloud-director /home/stack/images/ to this location and make a backup of overcloud-full.qcow2    
+Copy the `overcloud-full.qcow2` from undercloud-director /home/stack/images/ to this location and make a backup of overcloud-full.qcow2    
 
-`cp overcloud-full.qcow2 overcloud-full-bk.qcow2`
+    cp overcloud-full.qcow2 overcloud-full-bk.qcow2`
 
 
-Now run the below command by providing required values
+This script takes in `nuage_patching_config.yaml` as input parameters:  Please configure the following parameters. 
+  
+  * ImageName(required) is the name of the qcow2 image (for example, overcloud-full.qcow2)
+  * DeploymentType(required) is for user to specify which deployment is it. Please choose from "ovrs" or "avrs"
+        
+        Note: Currently Nuage doesn't support both AVRS and OVRS deployment together
+  * RhelUserName(optional) is the user name for the RedHat Enterprise Linux subscription.
+  * RhelPassword(optional) is the password for the RedHat Enterprise Linux subscription
+  * RhelPool(optional) is the RedHat Enterprise Linux pool to which the base packages are subscribed. instructions to get this can be found [here](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html/director_installation_and_usage/installing-the-undercloud#registering-and-updating-your-undercloud) in the 2nd point.
+  * RpmPublicKey(optional) is where you pass all the file path of the GPG key that you wish to add to your overcloud images before deploying the following packages.
+        
+        Note: 
+            Any Nuage package signing keys are delivered with other Nuage artifacts.  See "nuage-package-signing-keys-*.tar.gz". Mellanox signing keys can be found on their website.
+            Make sure to copy GPG-Key file(s) to the same folder as "nuage_overcloud_full_patch.py" patching script directory. 
+  * RepoFile(required) is the name of the repository hosting the RPMs required for patching. 
+                
+    **we are providing RepoFile exmaple `nuage_ospd13.repo.sample`** 
+    
+    **RepoFile can contain multiple repos. Please read following for more information about the repos in RepoFile:**
+  
+        [nuage] repo should have: ( We recommend user to enable this repo "enabled=1" by default as below packages will be installed via this repo)
+            nuage-puppet-modules
+            selinux-policy-nuage 
+            nuage-bgp 
+            nuage-openstack-neutronclient
+        
+        [nuage_vrs] repo should have:       
+            nuage-openvswitch 
+            nuage-metadata-agent
+        
+        [kernel repo] should have all the packages that are provided by Redhat as Kernel Hotfix.
+            kernel
+            kernel-tools
+            kernel-tools-libs
+            python-perf 
+        
+        [mlnx repo] should have all the packages that are provided by Mellanox.
+            kmod-mlnx-en
+            mlnx-en-utils
+            mstflint  
+            os-net-config
+        
+        [nuage_avrs] should have all the packages provided by Nuage for openvswitch and 6wind rpms.
+            nuage-openvswitch 
+            nuage-metadata-agent
+            6wind packages
+        
+        [extra] repo should have all the packages that we install as part of dependency packages:
+           libvirt
+           perl-JSON
+           lldpad
+  
+  * VRSRepoNames will contain Repo Names containing following Nuage O/VRS packages:
 
-### With GPG KEY
+        nuage-openvswitch 
+        nuage-metadata-agent
+        
+  * AVRSRepoNames will contain Repo Names containing following Nuage A/VRS and 6wind packages:
 
-#### Note: Any Nuage package signing keys are delivered with other Nuage artifacts.  See "nuage-package-signing-keys-*.tar.gz". Mellanox signing keys can be found on their website
+        nuage-openvswitch 
+        nuage-metadata-agent
+        6wind packages  
+        
+  * KernelRepoNames will contain Repo Names containing following packages:
 
-Make sure to copy GPG-Key file(s) to the same folder as "nuage_overcloud_full_patch.py" patching script location.
+        kernel
+        kernel-tools
+        kernel-tools-libs
+        python-perf
 
-For single GPG-Key run the below command
-`python nuage_overcloud_full_patch.py --RhelUserName='<value>' --RhelPassword='<value>' --RhelPool=<pool-id> --RepoName=<value> --RepoBaseUrl=http://IP/reponame --ImageName='<value>' --RpmPublicKey='GPG-Key'`
+  * MellanoxRepoNames will contain Repo Names containing following packages:
 
-For passing multiple GPG-keys, please repeat option "--RpmPublicKey" to set multiple GPG Keys, for example
-`python nuage_overcloud_full_patch.py --RhelUserName='<value>' --RhelPassword='<value>' --RhelPool=<pool-id> --RepoName=<value> --RepoBaseUrl=http://IP/reponame --ImageName='<value>' --RpmPublicKey='GPG-Key1' --RpmPublicKey='GPG-Key2'`
+        kmod-mlnx-en
+        mlnx-en-utils
+        mstflint
+        os-net-config
+         
+  **Note:** 
+  
+    RepoFile can also have additional repos enabled that user wish to enable while patching. 
+    It is highly recommended to disable AVRS and VRS by default (enabled =0) in the repo file and provide the AVRSRepoName & VRSRepoName in config file.  
+ 
+  * KernelHF, if set to True, kernel on the overcloud image will be updated to latest version present in KernelRepoNames. 
+  
+  * logFileName is to pass log file name
 
-### Without GPG Key
 
-`python nuage_overcloud_full_patch.py --RhelUserName='<value>' --RhelPassword='<value>' --RhelPool=<pool-id> --RepoName=<value> --RepoBaseUrl=http://IP/reponame --ImageName='<value>' --no-signing-key`
+Now run the below command by providing required values:
 
-This script takes in following input parameters:   
-  * RhelUserName is the user name for the RedHat Enterprise Linux subscription.
-  * RhelPassword is the password for the RedHat Enterprise Linux subscription
-  * RepoName is the name of the local repository hosting the Nuage RPMs.
-  * RepoBaseUrl is the base URL for the repository hosting the Nuage, Mellanox OFED and Red Hat Hot Fix RPMs (such as http://IP/reponame)
-  * RhelPool is the RedHat Enterprise Linux pool to which the base packages are subscribed. instructions to get this can be found [here](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html/director_installation_and_usage/installing-the-undercloud#registering-and-updating-your-undercloud) in the 2nd point.
-  * ImageName is the name of the qcow2 image (for example, overcloud-full.qcow2)
-  * RpmPublicKey is used to pass RPM GPG Key (repeat option to set multiple RPM GPG Keys)
-  * no-signing-key is for image patching to proceed with package signature verification disabled.
-  * logFile is to pass log file name.
+    python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
+
+
+### Some examples:
+
+###### 1. A/VRS deployment 
+
+1.1 Using different repos for nuage & 6wind package and No Redhat Subscription for dependent packages:
+
+    a. I have configured four different repos like following in my nuage_ospd13.repo:
+        
+        [nuage]
+        name=nuage_osp13_5.4.1.u4_nuage
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_extra
+        enabled=1
+        gpgcheck=1 
+               
+        [nuage_vrs]
+        name=nuage_osp13_5.4.1.u4_nuage_vrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_vrs
+        enabled=0
+        gpgcheck=1
+                
+        [nuage_avrs]
+        name=nuage_osp13_5.4.1.u4_nuage_avrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/avrs
+        enabled=0
+        gpgcheck=1
+        
+        [extra]
+        name=satellite
+        baseurl=http://1.2.3.4/extra_repo
+        enabled=1
+        gpgcheck=1
+    
+    b. Configure nuage_patching_config.yaml like:
+
+        ImageName: "overcloud-full.qcow2"
+        DeploymentType: ["avrs"]
+        RpmPublicKey: ['RPM-GPG-Nuage-key', 'RPM-GPG-SOMEOTHER-key']
+        RepoFile: './nuage_ospd13.repo'
+        VRSRepoNames: ['nuage_vrs']
+        AVRSRepoNames: ['nuage_avrs']
+        logFileName: "nuage_image_patching.log"
+        
+    c. Run: python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
+
+1.2 Using different repos for nuage & 6wind package and with Redhat Subscription for dependent packages:
+
+    a. I have configured four different repos like following in my nuage_ospd13.repo:
+        
+        [nuage]
+        name=nuage_osp13_5.4.1.u4_nuage
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_extra
+        enabled=1
+        gpgcheck=1 
+               
+        [nuage_vrs]
+        name=nuage_osp13_5.4.1.u4_nuage_vrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_vrs
+        enabled=0
+        gpgcheck=1
+                
+        [nuage_avrs]
+        name=nuage_osp13_5.4.1.u4_nuage_avrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/avrs
+        enabled=0
+        gpgcheck=1
+        
+    
+    b. Configure nuage_patching_config.yaml like:
+
+        ImageName: "overcloud-full.qcow2"
+        DeploymentType: ["avrs"]
+        RhelUserName: 'abc'
+        RhelPassword: '***'
+        RhelPool: '1234567890123445'
+        RpmPublicKey: ['RPM-GPG-Nuage-key', 'RPM-GPG-SOMEOTHER-key']
+        RepoFile: './nuage_ospd13.repo'
+        VRSRepoNames: ['nuage_vrs']
+        AVRSRepoNames: ['nuage_avrs']
+        logFileName: "nuage_image_patching.log"
+    
+    c. Run: python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
+
+
+###### 2. O/VRS Deployment
+
+2.1 Using different repos for nuage & kernel & mellanox packages and No Redhat Subscription for dependent packages:
+
+    a. I have configured four different repos like following in my nuage_ospd13.repo:
+        
+        [nuage]
+        name=nuage_osp13_5.4.1.u4_nuage
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_extra
+        enabled=1
+        gpgcheck=1 
+               
+        [nuage_vrs]
+        name=nuage_osp13_5.4.1.u4_nuage_ovrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_vrs
+        enabled=0
+        gpgcheck=1
+                
+        [mlnx]
+        name=nuage_osp13_5.4.1.u4_mlnx
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/mlnx/
+        enabled=0
+        gpgcheck=1
+        
+        [kernel]
+        name=nuage_osp13_5.4.1.u4_kernel
+        baseurl=http://1.2.3.4/kernel/
+        enabled=0
+        gpgcheck=1
+        
+        [extra]
+        name=satellite
+        baseurl=http://1.2.3.4/extra_repo
+        enabled=1
+        gpgcheck=1
+    
+    b. Configure nuage_patching_config.yaml like:
+
+        ImageName: "overcloud-full.qcow2"
+        DeploymentType: ["ovrs"]
+        RpmPublicKey: ['RPM-GPG-Nuage-key', 'RPM-GPG-SOMEOTHER-key']
+        RepoFile: './nuage_ospd13.repo'
+        VRSRepoNames: ['nuage_vrs']
+        MellanoxRepoNames: ['mlnx']
+        KernelRepoNames: ['kernel']
+        KernelHF: True
+        logFileName: "nuage_image_patching.log"
+    
+    c. Run: python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
+    
+2.2 Using different repos for nuage & kernel & mellanox packages and with Redhat Subscription for dependent packages:
+
+    a. I have configured four different repos like following in my nuage_ospd13.repo:
+        
+        [nuage]
+        name=nuage_osp13_5.4.1.u4_nuage
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_extra
+        enabled=1
+        gpgcheck=1 
+               
+        [nuage_vrs]
+        name=nuage_osp13_5.4.1.u4_nuage_ovrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_vrs
+        enabled=0
+        gpgcheck=1
+                
+        [mlnx]
+        name=nuage_osp13_5.4.1.u4_mlnx
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/mlnx/
+        enabled=0
+        gpgcheck=1
+        
+        [kernel]
+        name=nuage_osp13_5.4.1.u4_kernel
+        baseurl=http://1.2.3.4/kernel/
+        enabled=0
+        gpgcheck=1
+        
+        [extra]
+        name=satellite
+        baseurl=http://1.2.3.4/extra_repo
+        enabled=1
+        gpgcheck=1
+    
+    b. Configure nuage_patching_config.yaml like:
+
+        ImageName: "overcloud-full.qcow2"
+        DeploymentType: ["ovrs"]
+        RhelUserName: 'abc'
+        RhelPassword: '***'
+        RhelPool: '1234567890123445'
+        RpmPublicKey: ['RPM-GPG-Nuage-key', 'RPM-GPG-SOMEOTHER-key']
+        RepoFile: './nuage_ospd13.repo'
+        VRSRepoNames: ['nuage_vrs']
+        MellanoxRepoNames: ['mlnx']
+        KernelRepoNames: ['kernel']
+        KernelHF: True
+        logFileName: "nuage_image_patching.log"
+    
+    c. Run: python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
+
+2.2 Using different repos for nuage and same repo for kernel mellanox packages and No Redhat Subscription for dependent packages:
+
+    a. I have configured four different repos like following in my nuage_ospd13.repo:
+        
+        [nuage]
+        name=nuage_osp13_5.4.1.u4_nuage
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_extra
+        enabled=1
+        gpgcheck=1 
+               
+        [nuage_vrs]
+        name=nuage_osp13_5.4.1.u4_nuage_ovrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_vrs
+        enabled=0
+        gpgcheck=1
+                
+        [mlnx_kernel]
+        name=nuage_osp13_5.4.1.u4_mlnx
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/mlnx_kernel/
+        enabled=0
+        gpgcheck=1
+                
+        [extra]
+        name=satellite
+        baseurl=http://1.2.3.4/extra_repo
+        enabled=1
+        gpgcheck=1
+    
+    b. Configure nuage_patching_config.yaml like:
+
+        ImageName: "overcloud-full.qcow2"
+        DeploymentType: ["ovrs"]
+        RpmPublicKey: ['RPM-GPG-Nuage-key', 'RPM-GPG-SOMEOTHER-key']
+        RepoFile: './nuage_ospd13.repo'
+        VRSRepoNames: ['nuage_vrs']
+        MellanoxRepoNames: ['mlnx_kernel']
+        KernelRepoNames: ['mlnx_kernel']
+        KernelHF: True
+        logFileName: "nuage_image_patching.log"
+    
+    c. Run: python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
 
 If image patching fails for some reason then remove the partially patched overcloud-full.qcow2 and create a copy of it from backup image before retrying image patching again.   
 
-```
-rm overcloud-full.qcow2
-cp overcloud-full-bk.qcow2 overcloud-full.qcow2
-```
+    rm overcloud-full.qcow2
+    cp overcloud-full-bk.qcow2 overcloud-full.qcow2
+
 
 Once the patching is done successfully copy back the patched image to /home/stack/images/ on undercloud-director   
 
@@ -76,7 +364,8 @@ Run the below commands:
 +--------------------------------------+------------------------+
 ```
 
-then run the below commad   
+then run the below command   
+
 ```
 (undercloud) [stack@director images]$ openstack overcloud image upload --update-existing --image-path /home/stack/images/
 (undercloud) [stack@director images]$ openstack overcloud node configure $(openstack baremetal node list -c UUID -f value)

--- a/image-patching/stopgap-script/README.md
+++ b/image-patching/stopgap-script/README.md
@@ -1,9 +1,17 @@
-#Steps:
+# Requirements:
 
-Clone this repo onto the machine that is accessible to the nuage-rpms repo and make sure the machine also has `libguestfs-tools` and `libguestfs-tools-c` are installed.
+Required packages are `libguestfs-tools` and `python-yaml`
 
 ```
-yum install libguestfs-tools -y
+yum install libguestfs-tools python-yaml -y
+```
+
+
+# Steps:
+
+Clone this repo onto the hypervisor machine that is accessible to the nuage-rpms repo.
+
+```
 git clone https://github.com/nuagenetworks/nuage-ospdirector.git
 cd nuage-ospdirector
 git checkout OSPD13_VRS_offload
@@ -12,7 +20,7 @@ cd image-patching/stopgap-script/
 
 Copy the `overcloud-full.qcow2` from undercloud-director /home/stack/images/ to this location and make a backup of overcloud-full.qcow2    
 
-    cp overcloud-full.qcow2 overcloud-full-bk.qcow2`
+    cp overcloud-full.qcow2 overcloud-full-bk.qcow2
 
 
 This script takes in `nuage_patching_config.yaml` as input parameters:  Please configure the following parameters. 
@@ -29,13 +37,16 @@ This script takes in `nuage_patching_config.yaml` as input parameters:  Please c
         Note: 
             Any Nuage package signing keys are delivered with other Nuage artifacts.  See "nuage-package-signing-keys-*.tar.gz". Mellanox signing keys can be found on their website.
             Make sure to copy GPG-Key file(s) to the same folder as "nuage_overcloud_full_patch.py" patching script directory. 
-  * RepoFile(required) is the name of the repository hosting the RPMs required for patching. 
-                
+  * RepoFile(required) is the name of the repository hosting the RPMs required for patching.
+   
+        Note: 
+           Make sure to place repo file in the same folder as "nuage_overcloud_full_patch.py" patching script directory.
+                    
     **we are providing RepoFile exmaple `nuage_ospd13.repo.sample`** 
     
     **RepoFile can contain multiple repos. Please read following for more information about the repos in RepoFile:**
   
-        [nuage] repo should have: ( We recommend user to enable this repo "enabled=1" by default as below packages will be installed via this repo)
+        [nuage] repo should have: (We recommend user to enable this repo "enabled=1" by default as below packages will be installed via this repo)
             nuage-puppet-modules
             selinux-policy-nuage 
             nuage-bgp 

--- a/image-patching/stopgap-script/nuage_ospd13.repo.sample
+++ b/image-patching/stopgap-script/nuage_ospd13.repo.sample
@@ -1,0 +1,73 @@
+########################################################################################################################
+############## Repositories which user want to enable by default on the overcloud image while patching #################
+########################################################################################################################
+
+# This repo should contain following packages:
+# nuage-puppet-modules
+# selinux-policy-nuage
+# nuage-bgp
+# nuage-openstack-neutronclient
+[nuage]
+name=nuage_osp13_5.4.1.u4_nuage
+baseurl=http://<HOST-IP-HOSTING-REPOS>/nuage_osp13_5.4.1/nuage_extra
+enabled=1
+gpgcheck=1
+
+# These are some placeholder for some other repos that user want to enable these packages.
+# This repo should contain following packages:
+# libvirt
+# perl-JSON
+# lldpad
+# libguestfs-tools etc...
+[extra]
+name=satellite
+baseurl=http://satellite.com/extra_repo
+enabled=1
+gpgcheck=1
+
+
+########################################################################################################################
+############## Repositories which we recommend user to disable by default ##############################################
+########################################################################################################################
+
+# This repo should contain following packages:
+# nuage-openvswitch
+# nuage-metadata
+[nuage_vrs]
+name=nuage_osp13_5.4.1.u4_nuage
+baseurl=http://<HOST-IP-HOSTING-REPOS>/nuage_osp13_5.4.1/nuage_vrs
+enabled=1
+gpgcheck=1
+
+# This repo should contain following packages (Kernel HF provided by Redhat):
+# kernel
+# kernel-tools
+# kernel-tools-libs
+# python-perf
+[kernel]
+name=satellite1
+baseurl=http://<HOST-IP-HOSTING-REPOS>/repo
+enabled=0
+gpgcheck=1
+
+# kmod-mlnx-en
+# mlnx-en-utils
+# mstflint
+# os-net-config
+# Note: This is only required for OVRS Deployment.
+[mlnx]
+name=satellite2
+baseurl=http://<HOST-IP-HOSTING-REPOS>/repo
+enabled=0
+gpgcheck=1
+
+# This repo should contain following packages:
+# nuage-openvswitch
+# nuage-metadata
+# 6wind packages
+# Note: This is only required for AVRS Deployment
+[nuage_avrs]
+name=nuage_osp13_5.4.1.u4_avrs
+baseurl=http://<HOST-IP-HOSTING-REPOS>/nuage_osp13_5.4.1/avrs
+enabled=0
+gpgcheck=1

--- a/image-patching/stopgap-script/nuage_overcloud_full_patch.py
+++ b/image-patching/stopgap-script/nuage_overcloud_full_patch.py
@@ -1,52 +1,60 @@
+# !/usr/bin/python
+# Copyright 2019 NOKIA
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
 import argparse
 import subprocess
 import sys
 import logging
 import os
+import yaml
 
-#
-# This script is used to patch an existing OpenStack
-# image with Nuage components
-#
-# This script takes in following input parameters:
-# ImageName      : Name of the qcow2 image (overcloud-full.qcow2 for
-# example)
-# RhelUserName   : User name for the RHEL subscription
-# RhelPassword   : Password for the RHEL subscription
-# RhelPool       : RHEL Pool to subscribe
-# RepoName       : Name of the local repository
-# RepoBaseUrl    : Base URL of the local repository
-# RpmPublicKey   : RPM GPG Key (repeat option to set multiple RPM GPG
-#  Keys)
-# no-signing-key : Image patching proceeds with package signature
-# verification disabled
-# logFile        : Log file name
-#
-# The following sequence is executed by the script
-# 1. Subscribe to RHEL and the pool
-# 2. Uninstall OVS
-# 3. Create the local repo file for Nuage, Mellanox and Red Hat packages
-# 4. Update kernel to Red Hat Hot Fix
-# 5. Install nuage-openvswitch, nuage-metadata-agent and
-# nuage-openstack-neutronclient packages
-# 6. Install Mellanox OFED packages and add Mellanox os-net-config
-# scripts
-# 7. Unsubscribe from RHEL
-#
-#
+'''
+This script is used to patch an existing OpenStack
+image with Nuage components
+This script takes in following input parameters:
+ RhelUserName      : User name for the RHEL subscription
+ RhelPassword      : Password for the RHEL subscription
+ RhelPool          : RHEL Pool to subscribe
+ RepoFile          : Name for the file repo hosting the Nuage RPMs
+ VRSRepoNames       : Name for the repo hosting the Nuage O/VRS RPMs 
+ AVRSRepoNames      : Name for the repo hosting the Nuage AVRS RPMs
+ MellanoxRepoNames : Name for the repo hosting the Mellanox RPMs
+ KernelRepoNames   : Name for the repo hosting the Kernel RPMs
+ RpmPublicKey      : RPM GPG Key 
+ logFile           : Log file name
+The following sequence is executed by the script
+ 1. Subscribe to RHEL and the pool
+ 2. Uninstall OVS
+ 3. Download AVRS packages to the image if AVRS is enabled
+ 4. Install NeutronClient, Nuage-BGP, Selinux Policy Nuage, 
+    Nuage Puppet Module, Redhat HF and Mellanox packages.
+ 5. Install O/VRS, Nuage Metadata Agent
+ 6. Unsubscribe from RHEL
+'''
 
-### List of Nuage packages
-NUAGE_PACKAGES = "nuage-metadata-agent nuage-puppet-modules " \
-                 "selinux-policy-nuage nuage-bgp " \
-                 "nuage-openstack-neutronclient"
+# List of Nuage packages
+NUAGE_PACKAGES = "nuage-puppet-modules selinux-policy-nuage " \
+                 "nuage-bgp nuage-openstack-neutronclient"
 NUAGE_DEPENDENCIES = "libvirt perl-JSON lldpad"
-NUAGE_VRS_PACKAGE = "nuage-openvswitch"
+NUAGE_VRS_PACKAGE = "nuage-openvswitch nuage-metadata-agent"
 MLNX_OFED_PACKAGES = "kmod-mlnx-en mlnx-en-utils mstflint os-net-config"
 KERNEL_PACKAGES = "kernel kernel-tools kernel-tools-libs python-perf"
 VIRT_CUSTOMIZE_MEMSIZE = "2048"
-
-### Gpg value
-GPGCHECK = 1
+VIRT_CUSTOMIZE_ENV = "export LIBGUESTFS_BACKEND=direct;"
+SCRIPT_NAME = 'patching_script.sh'
+GPGKEYS_PATH = '/tmp/'
 
 logger = logging.getLogger('')
 logger.setLevel(logging.DEBUG)
@@ -61,19 +69,24 @@ logger.addHandler(consoleHandler)
 # Function to run commands on the console
 #####
 # quotes
+
+
 def cmds_run(cmds):
     if not cmds:
         return
     output_list = []
     for cmd in cmds:
-        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                shell=True, close_fds=True)
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
+            close_fds=True)
         (out, err) = proc.communicate()
         if err and err.split():
-            logger.error("error occurred during command:\n"
-                         " %s\n error:\n %s \n exiting" %
-                         (cmd, err))
+            logger.error(
+                "error occurred during command:\n %s\n error:\n %s \n "
+                "exiting" % (cmd, err))
             sys.exit(1)
         output_list.append(out)
 
@@ -88,296 +101,356 @@ def cmds_run(cmds):
 
 
 def virt_customize(command):
-    return cmds_run([
-        'export '
-        'LIBGUESTFS_BACKEND=direct;virt-customize '
-        '--run-command %s' % command])
+    return cmds_run(
+        [VIRT_CUSTOMIZE_ENV + 'virt-customize --run-command %s' % command])
 
 
 def virt_customize_run(command):
-    return cmds_run([
-        'export '
-        'LIBGUESTFS_BACKEND=direct;virt-customize '
-        '--run %s' % command])
+    return cmds_run([VIRT_CUSTOMIZE_ENV + 'virt-customize --run %s' % command])
 
 
 def virt_copy(command):
-    return cmds_run([
-        'export '
-        'LIBGUESTFS_BACKEND=direct;virt-copy-in -a '
-        '%s' % command])
+    return cmds_run([VIRT_CUSTOMIZE_ENV + 'virt-copy-in -a %s' % command])
+
+
+#####
+# Check if the provided path to the file exists
+#####
+
+
+def file_exists(filename):
+    if os.path.isfile(filename):
+        return True
+    else:
+        logger.error("%s is not present in the location of this "
+                     "script" % filename)
+        sys.exit(1)
 
 
 #####
 # Function to add RHEL subscription using guestfish
 #####
 
-def rhel_subscription(username, password, pool, image,
-                      proxy_hostname=None, proxy_port=None):
+
+def start_script():
+    if os.path.isfile(SCRIPT_NAME):
+        os.remove(SCRIPT_NAME)
+
+    cmds = '''#!/bin/bash
+set -xe
+'''
+    write_to_file(SCRIPT_NAME, cmds)
+
+
+#####
+# Function that writes commands to a file
+#####
+
+def write_to_file(filename, contents):
+    with open(filename, 'a') as script:
+        script.writelines(contents)
+
+
+#####
+# Function to add RHEL subscription using guestfish
+#####
+
+
+def rhel_subscription(username,
+                      password,
+                      pool,
+                      proxy_hostname=None,
+                      proxy_port=None):
     subscription_command = ''
-    if proxy_hostname != None:
-        subscription_command = subscription_command + \
-                               'cat <<EOT > ' \
-                               'rhel_subscription \n' \
-                               'subscription-manager config ' \
-                               '--server.proxy_hostname=%s' \
-                               ' --server.proxy_port=%s \n' % (
-                                   proxy_hostname, proxy_port)
-    else:
-        subscription_command = subscription_command + \
-                               'cat <<EOT > ' \
-                               'rhel_subscription \n'
+    if proxy_hostname is not None:
+        subscription_command = "subscription-manager config --server.proxy_hostname=%s  --server.proxy_port=%s\n" % (
+            proxy_hostname, proxy_port)
 
-    subscription_command = subscription_command + \
-                           'subscription-manager register ' \
-                           '--username=%s --password=\'%s\' \n' \
-                           'subscription-manager subscribe --pool=%s ' \
-                           '\n' \
-                           'subscription-manager repos ' \
-                           '--enable=rhel-7-server-optional-rpms \n' \
-                           'subscription-manager repos ' \
-                           '--enable=rhel-7-server-rpms \n' \
-                           'EOT' % (
-                               username, password, pool)
-    cmds_run([subscription_command])
-    virt_customize_run(
-        'rhel_subscription -a %s --memsize %s --selinux-relabel' % (
-            image, VIRT_CUSTOMIZE_MEMSIZE))
-
-    cmds_run(['rm -f rhel_subscription'])
+    enable_pool = '''
+subscription-manager register --username='%s' --password='%s'
+subscription-manager attach --pool='%s'
+subscription-manager repos --enable=rhel-7-server-optional-rpms
+subscription-manager repos --enable=rhel-7-server-rpms
+''' % (username, password, pool)
+    cmds = subscription_command + enable_pool
+    write_to_file(SCRIPT_NAME, cmds)
 
 
 #####
 # Function to remove the RHEL subscription
 #####
 
-def rhel_remove_subscription(image):
-    cmds_run(['cat <<EOT > rhel_unsubscribe \n'
-              'subscription-manager unregister \n'
-              'EOT'])
-    virt_customize_run(
-        'rhel_unsubscribe -a %s --memsize %s --selinux-relabel' % (
-            image, VIRT_CUSTOMIZE_MEMSIZE))
-    cmds_run(['rm -f rhel_unsubscribe'])
+
+def rhel_remove_subscription():
+    cmd = '''
+#### Removing RHEL Subscription
+subscription-manager unregister
+'''
+    write_to_file(SCRIPT_NAME, cmd)
 
 
 #####
 # Function to remove packages that are not needed
 #####
 
-def uninstall_packages(image):
-    virt_customize(
-        '"yum remove openvswitch -y" -a %s --memsize %s '
-        '--selinux-relabel' % (
-            image, VIRT_CUSTOMIZE_MEMSIZE))
+
+def uninstall_packages():
+    cmd = '''
+#### Removing Upstream OpenvSwitch
+yum remove openvswitch -y
+'''
+    write_to_file(SCRIPT_NAME, cmd)
 
 
 #####
 # Function to install Nuage packages that are required
 #####
 
-def install_packages(image):
-    cmds_run(['cat <<EOT > nuage_packages \n'
-              'yum install %s -y \n'
-              'yum install %s -y \n'
-              'yum install %s -y \n'
-              'EOT' % (
-                  NUAGE_DEPENDENCIES, NUAGE_PACKAGES,
-                  NUAGE_VRS_PACKAGE)])
-    virt_customize_run(
-        'nuage_packages -a %s --memsize %s --selinux-relabel' % (
-            image, VIRT_CUSTOMIZE_MEMSIZE))
-    cmds_run(['rm -f nuage_packages'])
+
+def install_nuage_packages(nuage_vrs_repos):
+    enable_repos_cmd = "yum-config-manager --enable"
+    for repo in nuage_vrs_repos:
+        enable_repos_cmd += " %s" % (repo)
+    disable_repos_cmd = enable_repos_cmd.replace("enable", "disable")
+
+    cmds = '''
+#### Installing Nuage Packages
+%s
+yum install --setopt=skip_missing_names_on_install=False -y %s
+yum install --setopt=skip_missing_names_on_install=False -y %s
+yum install --setopt=skip_missing_names_on_install=False -y %s
+%s
+''' % (enable_repos_cmd, NUAGE_DEPENDENCIES, NUAGE_VRS_PACKAGE,
+       NUAGE_PACKAGES, disable_repos_cmd)
+
+    write_to_file(SCRIPT_NAME, cmds)
 
 
 #####
-# Function to create the repo file
+# Function to install Mellanox packages that are required
 #####
 
-def create_repo_file(reponame, repoUrl, image, gpgcheck):
-    cmds_run(['cat <<EOT > create_repo \n'
-              'touch /etc/yum.repos.d/nuage.repo \n'
-              'echo "[Nuage]" >> /etc/yum.repos.d/nuage.repo \n'
-              'echo "name=%s" >> /etc/yum.repos.d/nuage.repo \n'
-              'echo "baseurl=%s" >> /etc/yum.repos.d/nuage.repo \n'
-              'echo "enabled = 1" >> /etc/yum.repos.d/nuage.repo \n'
-              'echo "gpgcheck =  %s" >> /etc/yum.repos.d/nuage.repo \n'
-              'EOT' % (reponame, repoUrl, gpgcheck)])
-    virt_customize_run(
-        'create_repo -a %s --memsize %s --selinux-relabel' % (
-            image, VIRT_CUSTOMIZE_MEMSIZE))
 
-
-#####
-# Function to clean up the repo file
-#####
-def delete_repo_file(image):
-    virt_customize(
-        '"rm -f /etc/yum.repos.d/nuage.repo" -a %s --selinux-relabel'
-        % (image))
-
-
-#####
-# Installing Mellanox Packages
-#####
-
-def install_mellanox(image):
-
+def install_mellanox(mellanox_repos):
     # Installing Mellanox OFED Packages
-    cmds_run(['cat <<EOT > mellanox_packages \n'
-              'yum install %s -y \n'
-              'systemctl disable mlnx-en.d \n'
-              'EOT' % (MLNX_OFED_PACKAGES)])
-    virt_customize_run(
-        'mellanox_packages -a %s --memsize %s --selinux-relabel' % (
-            image, VIRT_CUSTOMIZE_MEMSIZE))
-    cmds_run(['rm -f mellanox_packages'])
+    enable_repos_cmd = "yum-config-manager --enable"
+
+    for repo in mellanox_repos:
+        enable_repos_cmd += " %s" % (repo)
+    disable_repos_cmd = enable_repos_cmd.replace("enable", "disable")
+    cmds = '''
+#### Installing Mellanox OFED and os-net-config Packages
+%s
+yum clean all
+yum install --setopt=skip_missing_names_on_install=False -y %s
+systemctl disable mlnx-en.d
+%s
+''' % (enable_repos_cmd, MLNX_OFED_PACKAGES, disable_repos_cmd)
+    write_to_file(SCRIPT_NAME, cmds)
 
 
 #####
 # Updating kernel to Red Hat Hot Fix
 #####
 
-def update_kernel(image):
+
+def update_kernel(rh_repos):
     # Updating Kernel
-    cmds_run(['cat <<EOT > kernel_packages \n'
-              'yum install %s -y \n'
-              'EOT' % (KERNEL_PACKAGES)])
-    virt_customize_run(
-        'kernel_packages -a %s --memsize %s --selinux-relabel' % (
-            image, VIRT_CUSTOMIZE_MEMSIZE))
-    cmds_run(['rm -f kernel_packages'])
+    enable_repos_cmd = "yum-config-manager --enable"
+    for repo in rh_repos:
+        enable_repos_cmd += " %s" % (repo)
+    disable_repos_cmd = enable_repos_cmd.replace("enable", "disable")
+    cmds = '''
+#### Installing Kernel Hot Fix Packages
+%s
+yum clean all
+yum install --setopt=skip_missing_names_on_install=False -y %s
+%s
+''' % (enable_repos_cmd, KERNEL_PACKAGES, disable_repos_cmd)
+    write_to_file(SCRIPT_NAME, cmds)
+
+
+#####
+# Function to install Nuage AVRS packages that are required
+#####
+
+
+def download_avrs_packages(nuage_avrs_repos):
+    enable_repos_cmd = "yum-config-manager --enable"
+    for repo in nuage_avrs_repos:
+        enable_repos_cmd += " %s" % (repo)
+    disable_repos_cmd = enable_repos_cmd.replace("enable", "disable")
+    cmds = '''
+#### Downloading Nuage Avrs and 6wind Packages
+%s
+mkdir -p /6wind
+rm -rf /var/cache/yum/Nuage
+yum clean all
+touch /kernel-version
+rpm -q kernel | awk '{ print substr($1,8) }' > /kernel-version
+yum install --setopt=skip_missing_names_on_install=False -y createrepo
+yum install --setopt=skip_missing_names_on_install=False --downloadonly --downloaddir=/6wind kernel-headers-$(awk 'END{print}' /kernel-version) kernel-devel-$(awk 'END{print}' /kernel-version) python-pyelftools* dkms* 6windgate*
+yum install --setopt=skip_missing_names_on_install=False --downloadonly --downloaddir=/6wind nuage-openvswitch nuage-metadata-agent
+yum install --setopt=skip_missing_names_on_install=False --downloadonly --downloaddir=/6wind virtual-accelerator*
+yum install --setopt=skip_missing_names_on_install=False --downloadonly --downloaddir=/6wind selinux-policy-nuage-avrs*
+yum install --setopt=skip_missing_names_on_install=False --downloadonly --downloaddir=/6wind 6wind-openstack-extensions
+rm -rf /kernel-version
+yum clean all
+%s
+''' % (enable_repos_cmd, disable_repos_cmd)
+    write_to_file(SCRIPT_NAME, cmds)
 
 
 #####
 # Importing Gpgkeys to Overcloud image
 #####
 
-def importing_gpgkeys(image, workingDir, gpgkeys):
+
+def importing_gpgkeys(image, gpgkeys):
+    cmd = '''
+#### Importing GPG keys
+'''
+    write_to_file(SCRIPT_NAME, cmd)
     for gpgkey in gpgkeys:
-        file_exists = os.path.isfile(gpgkey[0])
+        file_exists = os.path.isfile(gpgkey)
+        file_name = os.path.basename(gpgkey)
         if file_exists:
-            virt_copy('%s %s/%s /tmp/' % (image, workingDir, gpgkey[0]))
-            virt_customize(
-                '"rpm --import /tmp/%s" -a %s --memsize %s '
-                '--selinux-relabel' % (
-                    gpgkey[0], image, VIRT_CUSTOMIZE_MEMSIZE))
+            virt_copy('%s %s %s' % (image, gpgkey, GPGKEYS_PATH))
+            rpm_import = '''
+rpm --import %s%s
+''' % (GPGKEYS_PATH, file_name)
+            write_to_file(SCRIPT_NAME, rpm_import)
+
         else:
-            logger.error(
-                "Nuage package signing key is not present in %s ,"
-                "Installation cannot proceed.  Please place the "
-                "signing key in the correct location and retry" % (
-                    gpgkey[0]))
+            logger.error("Nuage package signing key is not present in %s ,"
+                         "Installation cannot proceed.  Please place the "
+                         "signing key in the correct location and retry" %
+                         gpgkey)
+
             sys.exit(1)
 
 
-def image_patching(args):
+####
+# Copying repo file to overcloud image
+####
 
-    global GPGCHECK
 
-    if args.logFile:
-        handler = logging.FileHandler(args.logFile)
+def copy_repo_file(image, repofile):
+    if os.path.isfile(repofile):
+        virt_copy('%s %s /etc/yum.repos.d/' % (image, repofile))
+    else:
+        logger.error("Repo file doesn't exists at %s"
+                     "Please provide the correct path of RepoFile" %
+                     repofile)
+        sys.exit(1)
+
+
+####
+# Image Patching
+####
+
+
+def image_patching(nuage_config):
+    if nuage_config.get("logFileName"):
+        handler = logging.FileHandler(nuage_config["logFileName"])
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
-    workingDir = os.path.dirname(os.path.abspath(__file__))
+    start_script()
 
-    if not args.no_signing_key and args.RpmPublicKey == None:
-        logger.error(
-            "'--RpmPublicKey' or '--no-signing-key' are not passed in "
-            "image patching command, If verification of "
-            "Nuage-supplied packages is not required, please restart "
-            "image patching with the --no-signing-key option.")
-        sys.exit(1)
+    if nuage_config.get("RpmPublicKey"):
+        logger.info("Importing gpgkey(s) to overcloud image")
+        importing_gpgkeys(nuage_config["ImageName"],
+                          nuage_config["RpmPublicKey"])
 
-    if args.no_signing_key:
-        logger.warning(
-            "Image patching proceeding with package signature "
-            "verification disabled. Nuage packages installed will not "
-            "have package signatures verified.")
-        GPGCHECK = 0
-
-    cmds_run(['echo "Verifying pre-requisite packages for script"'])
-    libguestfs = cmds_run(['rpm -q libguestfs-tools-c'])
-    if 'not installed' in libguestfs:
-        cmds_run([
-            'echo "Please install libguestfs-tools-c package '
-            'for the script to run"'])
-        sys.exit()
-
-    if args.RpmPublicKey:
-        cmds_run(['echo "Importing gpgkey(s) to overcloud image"'])
-        importing_gpgkeys(args.ImageName, workingDir, args.RpmPublicKey)
-
-    if args.RhelUserName and args.RhelPassword and args.RhelPool:
-        cmds_run(['echo "Creating the RHEL subscription"'])
-        if args.ProxyHostname and args.ProxyPort:
-            rhel_subscription(args.RhelUserName, args.RhelPassword,
-                              args.RhelPool,
-                              args.ImageName, args.ProxyHostname,
-                              args.ProxyPort)
+    if nuage_config.get("RhelUserName") and nuage_config.get(
+            "RhelPassword") and nuage_config.get("RhelPool"):
+        if nuage_config.get("ProxyHostname") and nuage_config.get("ProxyPort"):
+            rhel_subscription(
+                nuage_config["RhelUserName"], nuage_config["RhelPassword"],
+                nuage_config["RhelPool"], nuage_config["ProxyHostname"],
+                nuage_config["ProxyPort"])
         else:
-            rhel_subscription(args.RhelUserName, args.RhelPassword,
-                              args.RhelPool,
-                              args.ImageName)
+            rhel_subscription(
+                nuage_config["RhelUserName"], nuage_config["RhelPassword"],
+                nuage_config["RhelPool"])
+    uninstall_packages()
 
-    cmds_run(['echo "Uninstalling packages"'])
-    uninstall_packages(args.ImageName)
+    logger.info("Copying RepoFile to the overcloud image")
+    copy_repo_file(nuage_config["ImageName"], nuage_config["RepoFile"])
 
-    cmds_run(['echo "Creating Repo File"'])
-    create_repo_file(args.RepoName, args.RepoBaseUrl, args.ImageName,
-                     GPGCHECK)
+    if nuage_config['KernelHF']:
+        update_kernel(nuage_config["KernelRepoNames"])
 
-    cmds_run(['echo "Updating Kernel"'])
-    update_kernel(args.ImageName)
+    if "ovrs" in nuage_config["DeploymentType"]:
+        install_mellanox(nuage_config["MellanoxRepoNames"])
 
-    cmds_run(['echo "Installing Nuage Packages"'])
-    install_packages(args.ImageName)
+    if "avrs" in nuage_config["DeploymentType"]:
+        download_avrs_packages(nuage_config["AVRSRepoNames"])
 
-    cmds_run(['echo "Installing MLNX OFED and os-net-config Packages"'])
-    install_mellanox(args.ImageName)
+    install_nuage_packages(nuage_config["VRSRepoNames"])
 
-    cmds_run(['echo "Cleaning up"'])
-    delete_repo_file(args.ImageName)
+    if nuage_config.get("RhelUserName") and nuage_config.get(
+            "RhelPassword") and nuage_config.get("RhelPool"):
+        rhel_remove_subscription()
 
-    if args.RhelUserName and args.RhelPassword and args.RhelPool:
-        rhel_remove_subscription(args.ImageName)
+    logger.info("Running the patching script on Overcloud image")
+    virt_customize_run(
+        ' %s -a %s --memsize %s --selinux-relabel' % (
+            SCRIPT_NAME, nuage_config["ImageName"],
+            VIRT_CUSTOMIZE_MEMSIZE))
+    logger.info("Done")
 
-    cmds_run(['echo "Done"'])
+
+def check_config(nuage_config):
+    missing_config = []
+    for key in ["ImageName", "DeploymentType", "RepoFile", "VRSRepoNames"]:
+        if not (nuage_config.get(key)):
+            missing_config.append(key)
+    if missing_config:
+        logger.error("Please provide missing config %s value "
+                     "in your config file. \n" % missing_config)
+        sys.exit(1)
+    if "avrs" in nuage_config["DeploymentType"] and "ovrs" in nuage_config["DeploymentType"]:
+        logger.error(
+            "Currently Nuage doesn't support both AVRS and OVRS deployment together"
+            "Please choose only one between them")
+        sys.exit(1)
+    if "avrs" in nuage_config["DeploymentType"]:
+        if not nuage_config.get("AVRSRepoNames"):
+            logger.error("Please provide AVRSRepoNames for AVRS deployment")
+            sys.exit(1)
+    if "ovrs" in nuage_config["DeploymentType"]:
+        for reponame in ["KernelRepoNames", "MellanoxRepoNames"]:
+            if not nuage_config.get(reponame):
+                logger.error(
+                    "Please provide %s for OVRS deployment" % reponame)
+                sys.exit(1)
+
+    logger.info("Verifying pre-requisite packages for script")
+    libguestfs = cmds_run(['rpm -q libguestfs-tools'])
+    if 'not installed' in libguestfs:
+        logger.info("Please install libguestfs-tools package for the script to run")
+        sys.exit(1)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--ImageName", type=str, required=True,
-                        help="Name of the qcow2 image ("
-                             "overcloud-full.qcow2 for example)")
-    parser.add_argument("--RhelUserName", type=str,
-                        help="User name for RHELSubscription")
-    parser.add_argument("--RhelPassword", type=str,
-                        help="Password for the RHEL Subscription")
-    parser.add_argument("--RhelPool", type=str,
-                        help="Pool to subscribe to for base packages")
-    parser.add_argument("--RepoName", type=str, default='Nuage',
-                        help="Name for the local repo hosting the "
-                             "Nuage RPMs")
-    parser.add_argument("--RepoBaseUrl", type=str, required=True,
-                        help="Base URL for the repo hosting the Nuage "
-                             "VRS RPMs")
-    parser.add_argument("--RpmPublicKey", action='append', nargs=1,
-                        help="RPM GPG Key (repeat option to set "
-                             "multiple RPM GPG Keys)")
-    parser.add_argument("--no-signing-key", dest="no_signing_key",
-                        action="store_true",
-                        help="Image patching proceeds with package "
-                             "signature verification disabled")
-    parser.add_argument("--ProxyHostname", type=str,
-                        help="Proxy Hostname")
-    parser.add_argument("--ProxyPort", type=str, help="Proxy Port")
-    parser.add_argument("--logFile", type=str,
-                        default='nuage_image_patching.log',
-                        help="Log file name")
+    parser.add_argument(
+        "--nuage-config",
+        dest="nuage_config",
+        type=str,
+        required=True,
+        help="path to nuage_patching_config.yaml")
     args = parser.parse_args()
-    image_patching(args)
+
+    try:
+        with open(args.nuage_config) as nuage_config:
+            nuage_config = yaml.load(nuage_config)
+    except Exception:
+        raise
+    check_config(nuage_config)
+    image_patching(nuage_config)
 
 
 if __name__ == "__main__":

--- a/image-patching/stopgap-script/nuage_patching_config.yaml
+++ b/image-patching/stopgap-script/nuage_patching_config.yaml
@@ -19,7 +19,7 @@ RhelUserName: ''
 # optional
 RhelPassword: ''
 
-#Pool to subscribe to for base packages
+# Pool to subscribe to for base packages
 # type: string
 # optional
 RhelPool: ''
@@ -27,11 +27,13 @@ RhelPool: ''
 # RPM GPG Key
 # type: list
 # optional
+# Note: Make sure to copy GPG-Key file(s) to the same folder as "nuage_overcloud_full_patch.py"
 RpmPublicKey: []
 
 # Path for the Repo File
 # type: string
 # required
+# Note: Make sure to place repo file in the same folder as "nuage_overcloud_full_patch.py"
 RepoFile: ''
 
 # Name for the repo hosting the Nuage O/VRS RPMs

--- a/image-patching/stopgap-script/nuage_patching_config.yaml
+++ b/image-patching/stopgap-script/nuage_patching_config.yaml
@@ -1,0 +1,77 @@
+# Name of the qcow2 image
+# type: string
+# required
+ImageName: "overcloud-full.qcow2"
+
+# DeploymentType for your Deployment
+# type: string
+# required ( Please choose one of them )
+# Eg:  ["ovrs"] or ["avrs"]
+DeploymentType: []
+
+# User name for RHEL Subscription
+# type: string
+# optional
+RhelUserName: ''
+
+# Password for the RHEL Subscription 
+# type: string
+# optional
+RhelPassword: ''
+
+#Pool to subscribe to for base packages
+# type: string
+# optional
+RhelPool: ''
+
+# RPM GPG Key
+# type: list
+# optional
+RpmPublicKey: []
+
+# Path for the Repo File
+# type: string
+# required
+RepoFile: ''
+
+# Name for the repo hosting the Nuage O/VRS RPMs
+# type:  list
+# required
+# Eg:  ["vrs_repo_name1", "vrs_repo_name2"]
+VRSRepoNames: []
+
+# Name for the repo hosting the Nuage AVRS RPMs 
+# type: list
+# optional
+# Eg:  ["avrs_repo_name1", "avrs_repo_name2"]
+AVRSRepoNames: []
+
+# Name for the repo hosting the Mellanox and os-net-config RPMs
+# type: list
+# optional
+# Eg:  ["mlnx_repo_name1", "mlnx_repo_name2"]
+MellanoxRepoNames: []
+
+# Name for the repo hosting the Kernel RPMs
+# type: list
+# optional
+# Eg:  ["rh_kernel_repo_name1", "rh_kernel_repo_name2"]
+KernelRepoNames: []
+
+# To install Kernel Hot Fix or not and defaults to False.
+# When this is set to True, KernelRepoNames can't be empty.
+# type: boolean
+# optional
+# Eg: KernelHF: True
+KernelHF: False
+
+# Log file name
+# type: string
+# optional
+logFileName: "nuage_image_patching.log"
+
+# If you are behind Proxy you can enter Proxy Server information here
+# type: string
+# optional
+ProxyHostname: ''
+ProxyPort: ''


### PR DESCRIPTION
- Now patching accepts the nuage_patching_config.yaml
- Same script can be used for VRS/AVRS/OVRS patching
- Whole patching is done by calling virt-customize only once instead of many.
- Patching script accepts single repo file, which can have multiple repositories.
- if there are any missing packages while installing, patching script will detect it and stop/fail.
- For OVRS, copying of os-net-config scripts is removed and support for installing hot fix os-net-config is added.