### PR TITLE
fixing OPENSTACK-2616 and OPENSTACK-2605

### DIFF
--- a/nuage-tripleo-heat-templates/environments/neutron-nuage-config.yaml
+++ b/nuage-tripleo-heat-templates/environments/neutron-nuage-config.yaml
@@ -41,3 +41,12 @@ parameter_defaults:
     directories: [{'allow_override': ['None'], 'path': '/usr/lib/python2.7/site-packages/nuage_horizon', 'require': 'all granted', 'options': ['FollowSymLinks']}]
     add_listen: True
     aliases: [{'alias': '%{root_url}/static/nuage', 'path': '/usr/lib/python2.7/site-packages/nuage_horizon/static'}, {'alias': '%{root_url}/static', 'path': '/usr/share/openstack-dashboard/static'}]
+  ControllerExtraConfig:
+    neutron::config::server_config:
+      DEFAULT/ipam_driver:
+        value: nuage_internal
+      DEFAULT/enable_snat_by_default:
+        value: false
+    neutron::config::plugin_nuage_config:
+      RESTPROXY/nuage_pat:
+        value: legacy_disabled


### PR DESCRIPTION
This change resolve the following:

OPENSTACK-2616 : 
Using this changes, all overcloud deployments will have new pat model configurations
* enable_snat_by_default=false in /etc/neturon/neutron.conf
* nuage_pat=legacy_disabled in 
/etc/neutron/plugins/nuage/plugin.ini

OPENSTACK-2605: OSPD should always set ipam_driver in 5.4.1 U4 and onwards