### PR TITLE
fixing OPENSTACK-2631

### DIFF
--- a/nuage-tripleo-heat-templates/environments/neutron-nuage-config.yaml
+++ b/nuage-tripleo-heat-templates/environments/neutron-nuage-config.yaml
@@ -45,3 +45,8 @@ parameter_defaults:
     neutron::config::server_config:
       DEFAULT/ipam_driver:
         value: nuage_internal
+      DEFAULT/enable_snat_by_default:
+        value: false
+    neutron::config::plugin_nuage_config:
+      RESTPROXY/nuage_pat:
+        value: legacy_disabled


### PR DESCRIPTION
Using this changes, all overcloud deployments will have new pat model configurations
* enable_snat_by_default=false in /etc/neturon/neutron.conf
* nuage_pat=legacy_disabled in 
/etc/neutron/plugins/nuage/plugin.ini