### PR TITLE
fixing: OPENSTACK-2620/2650 & PROD-10354/10407/10432 (OSPD13)

### DIFF
--- a/image-patching/stopgap-script/README.md
+++ b/image-patching/stopgap-script/README.md
@@ -1,9 +1,17 @@
-#Steps:
+# Requirements:
 
-Clone this repo onto the machine that is accessible to the nuage-rpms repo and make sure the machine also has `libguestfs-tools` and `libguestfs-tools-c` are installed.
+Required packages are `libguestfs-tools` and `python-yaml`
 
 ```
-yum install libguestfs-tools -y
+yum install libguestfs-tools python-yaml -y
+```
+
+
+# Steps:
+
+Clone this repo onto the hypervisor machine that is accessible to the nuage-rpms repo.
+
+```
 git clone https://github.com/nuagenetworks/nuage-ospdirector.git
 cd nuage-ospdirector
 git checkout OSPD13
@@ -12,7 +20,7 @@ cd image-patching/stopgap-script/
 
 Copy the `overcloud-full.qcow2` from undercloud-director /home/stack/images/ to this location and make a backup of overcloud-full.qcow2    
 
-    cp overcloud-full.qcow2 overcloud-full-bk.qcow2`
+    cp overcloud-full.qcow2 overcloud-full-bk.qcow2
 
 
 This script takes in `nuage_patching_config.yaml` as input parameters:  Please configure the following parameters. 
@@ -29,13 +37,16 @@ This script takes in `nuage_patching_config.yaml` as input parameters:  Please c
         Note: 
             Any Nuage package signing keys are delivered with other Nuage artifacts.  See "nuage-package-signing-keys-*.tar.gz". Mellanox signing keys can be found on their website.
             Make sure to copy GPG-Key file(s) to the same folder as "nuage_overcloud_full_patch.py" patching script directory. 
-  * RepoFile(required) is the name of the repository hosting the RPMs required for patching. 
-                
+  * RepoFile(required) is the name of the repository hosting the RPMs required for patching.
+   
+        Note: 
+           Make sure to place repo file in the same folder as "nuage_overcloud_full_patch.py" patching script directory.
+                    
     **we are providing RepoFile exmaple `nuage_ospd13.repo.sample`** 
     
     **RepoFile can contain multiple repos. Please read following for more information about the repos in RepoFile:**
   
-        [nuage] repo should have: ( We recommend user to enable this repo "enabled=1" by default as below packages will be installed via this repo)
+        [nuage] repo should have: (We recommend user to enable this repo "enabled=1" by default as below packages will be installed via this repo)
             nuage-puppet-modules
             selinux-policy-nuage 
             nuage-bgp 

--- a/image-patching/stopgap-script/README.md
+++ b/image-patching/stopgap-script/README.md
@@ -1,6 +1,6 @@
-Steps:
+#Steps:
 
-Clone this repo onto the machine that is accessible to the nuage-rpms repo and make sure the machine also has `libguestfs-tools` installed.
+Clone this repo onto the machine that is accessible to the nuage-rpms repo and make sure the machine also has `libguestfs-tools` and `libguestfs-tools-c` are installed.
 
 ```
 yum install libguestfs-tools -y
@@ -10,64 +10,334 @@ git checkout OSPD13
 cd image-patching/stopgap-script/
 ```
 
-Copy the overcloud-full.qcow2 from undercloud-director /home/stack/images/ to this location and make a backup of overcloud-full.qcow2    
+Copy the `overcloud-full.qcow2` from undercloud-director /home/stack/images/ to this location and make a backup of overcloud-full.qcow2    
 
-`cp overcloud-full.qcow2 overcloud-full-bk.qcow2`
+    cp overcloud-full.qcow2 overcloud-full-bk.qcow2`
 
 
-
-Now run the below command by providing required values   
+This script takes in `nuage_patching_config.yaml` as input parameters:  Please configure the following parameters. 
+  
+  * ImageName(required) is the name of the qcow2 image (for example, overcloud-full.qcow2)
+  * DeploymentType(required) is for user to specify which deployment is it. Please choose from "ovrs" or "avrs"
+        
+        Note: Currently Nuage doesn't support both AVRS and OVRS deployment together
+  * RhelUserName(optional) is the user name for the RedHat Enterprise Linux subscription.
+  * RhelPassword(optional) is the password for the RedHat Enterprise Linux subscription
+  * RhelPool(optional) is the RedHat Enterprise Linux pool to which the base packages are subscribed. instructions to get this can be found [here](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html/director_installation_and_usage/installing-the-undercloud#registering-and-updating-your-undercloud) in the 2nd point.
+  * RpmPublicKey(optional) is where you pass all the file path of the GPG key that you wish to add to your overcloud images before deploying the following packages.
+        
+        Note: 
+            Any Nuage package signing keys are delivered with other Nuage artifacts.  See "nuage-package-signing-keys-*.tar.gz". Mellanox signing keys can be found on their website.
+            Make sure to copy GPG-Key file(s) to the same folder as "nuage_overcloud_full_patch.py" patching script directory. 
+  * RepoFile(required) is the name of the repository hosting the RPMs required for patching. 
+                
+    **we are providing RepoFile exmaple `nuage_ospd13.repo.sample`** 
     
-### With GPG Key(s)  
+    **RepoFile can contain multiple repos. Please read following for more information about the repos in RepoFile:**
+  
+        [nuage] repo should have: ( We recommend user to enable this repo "enabled=1" by default as below packages will be installed via this repo)
+            nuage-puppet-modules
+            selinux-policy-nuage 
+            nuage-bgp 
+            nuage-openstack-neutronclient
+        
+        [nuage_vrs] repo should have:       
+            nuage-openvswitch 
+            nuage-metadata-agent
+        
+        [kernel repo] should have all the packages that are provided by Redhat as Kernel Hotfix.
+            kernel
+            kernel-tools
+            kernel-tools-libs
+            python-perf 
+        
+        [mlnx repo] should have all the packages that are provided by Mellanox.
+            kmod-mlnx-en
+            mlnx-en-utils
+            mstflint  
+            os-net-config
+        
+        [nuage_avrs] should have all the packages provided by Nuage for openvswitch and 6wind rpms.
+            nuage-openvswitch 
+            nuage-metadata-agent
+            6wind packages
+        
+        [extra] repo should have all the packages that we install as part of dependency packages:
+           libvirt
+           perl-JSON
+           lldpad
+  
+  * VRSRepoNames will contain Repo Names containing following Nuage O/VRS packages:
 
-Make sure to copy GPG-Key file(s) to the same folder as "nuage_overcloud_full_patch.py" patching script location.
+        nuage-openvswitch 
+        nuage-metadata-agent
+        
+  * AVRSRepoNames will contain Repo Names containing following Nuage A/VRS and 6wind packages:
 
-For single GPG-key run the below command
-`python nuage_overcloud_full_patch.py --RhelUserName='<value>' --RhelPassword='<value>' --RhelPool=<pool-id> --RepoName=<value> --RepoBaseUrl=http://IP/reponame --ImageName='<value>' --Version=13 --RpmPublicKey='GPG-Key'`
+        nuage-openvswitch 
+        nuage-metadata-agent
+        6wind packages  
+        
+  * KernelRepoNames will contain Repo Names containing following packages:
+
+        kernel
+        kernel-tools
+        kernel-tools-libs
+        python-perf
+
+  * MellanoxRepoNames will contain Repo Names containing following packages:
+
+        kmod-mlnx-en
+        mlnx-en-utils
+        mstflint
+        os-net-config
+         
+  **Note:** 
+  
+    RepoFile can also have additional repos enabled that user wish to enable while patching. 
+    It is highly recommended to disable AVRS and VRS by default (enabled =0) in the repo file and provide the AVRSRepoName & VRSRepoName in config file.  
+ 
+  * KernelHF, if set to True, kernel on the overcloud image will be updated to latest version present in KernelRepoNames. 
+  
+  * logFileName is to pass log file name
 
 
-For AVRS Integration with single GPG-key, please run below command
+Now run the below command by providing required values:
 
-`python nuage_overcloud_full_patch.py --RhelUserName='<value>' --RhelPassword='<value>' --RhelPool=<pool-id> --RepoName=<value> --RepoBaseUrl=http://IP/reponame --AVRSBaseUrl=http://IP/reponame --ImageName='<value>' --Version=13 --RpmPublicKey='GPG-Key'`
-
-
-For passing multiple GPG-keys, please repeat option "--RpmPublicKey" to set multiple GPG keys, for example
-
-`python nuage_overcloud_full_patch.py --RhelUserName='<value>' --RhelPassword='<value>' --RhelPool=<pool-id> --RepoName=<value> --RepoBaseUrl=http://IP/reponame --ImageName='<value>' --Version=13 --RpmPublicKey='GPG-Key1' --RpmPublicKey='GPG-Key2'`
+    python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
 
 
-For AVRS Integration with multiple GPG-keys, please run below command
+### Some examples:
 
-`python nuage_overcloud_full_patch.py --RhelUserName='<value>' --RhelPassword='<value>' --RhelPool=<pool-id> --RepoName=<value> --RepoBaseUrl=http://IP/reponame --AVRSBaseUrl=http://IP/reponame --ImageName='<value>' --Version=13 --RpmPublicKey='GPG-Key1' --RpmPublicKey='GPG-Key2'`
+###### 1. A/VRS deployment 
+
+1.1 Using different repos for nuage & 6wind package and No Redhat Subscription for dependent packages:
+
+    a. I have configured four different repos like following in my nuage_ospd13.repo:
+        
+        [nuage]
+        name=nuage_osp13_5.4.1.u4_nuage
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_extra
+        enabled=1
+        gpgcheck=1 
+               
+        [nuage_vrs]
+        name=nuage_osp13_5.4.1.u4_nuage_vrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_vrs
+        enabled=0
+        gpgcheck=1
+                
+        [nuage_avrs]
+        name=nuage_osp13_5.4.1.u4_nuage_avrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/avrs
+        enabled=0
+        gpgcheck=1
+        
+        [extra]
+        name=satellite
+        baseurl=http://1.2.3.4/extra_repo
+        enabled=1
+        gpgcheck=1
+    
+    b. Configure nuage_patching_config.yaml like:
+
+        ImageName: "overcloud-full.qcow2"
+        DeploymentType: ["avrs"]
+        RpmPublicKey: ['RPM-GPG-Nuage-key', 'RPM-GPG-SOMEOTHER-key']
+        RepoFile: './nuage_ospd13.repo'
+        VRSRepoNames: ['nuage_vrs']
+        AVRSRepoNames: ['nuage_avrs']
+        logFileName: "nuage_image_patching.log"
+        
+    c. Run: python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
+
+1.2 Using different repos for nuage & 6wind package and with Redhat Subscription for dependent packages:
+
+    a. I have configured four different repos like following in my nuage_ospd13.repo:
+        
+        [nuage]
+        name=nuage_osp13_5.4.1.u4_nuage
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_extra
+        enabled=1
+        gpgcheck=1 
+               
+        [nuage_vrs]
+        name=nuage_osp13_5.4.1.u4_nuage_vrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_vrs
+        enabled=0
+        gpgcheck=1
+                
+        [nuage_avrs]
+        name=nuage_osp13_5.4.1.u4_nuage_avrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/avrs
+        enabled=0
+        gpgcheck=1
+        
+    
+    b. Configure nuage_patching_config.yaml like:
+
+        ImageName: "overcloud-full.qcow2"
+        DeploymentType: ["avrs"]
+        RhelUserName: 'abc'
+        RhelPassword: '***'
+        RhelPool: '1234567890123445'
+        RpmPublicKey: ['RPM-GPG-Nuage-key', 'RPM-GPG-SOMEOTHER-key']
+        RepoFile: './nuage_ospd13.repo'
+        VRSRepoNames: ['nuage_vrs']
+        AVRSRepoNames: ['nuage_avrs']
+        logFileName: "nuage_image_patching.log"
+    
+    c. Run: python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
 
 
-### Without GPG Key
+###### 2. O/VRS Deployment
 
-`python nuage_overcloud_full_patch.py --RhelUserName='<value>' --RhelPassword='<value>' --RhelPool=<pool-id> --RepoName=<value> --RepoBaseUrl=http://IP/reponame --ImageName='<value>' --Version=13 --no-signing-key`
+2.1 Using different repos for nuage & kernel & mellanox packages and No Redhat Subscription for dependent packages:
 
-For AVRS Integration, Please run below command
+    a. I have configured four different repos like following in my nuage_ospd13.repo:
+        
+        [nuage]
+        name=nuage_osp13_5.4.1.u4_nuage
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_extra
+        enabled=1
+        gpgcheck=1 
+               
+        [nuage_vrs]
+        name=nuage_osp13_5.4.1.u4_nuage_ovrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_vrs
+        enabled=0
+        gpgcheck=1
+                
+        [mlnx]
+        name=nuage_osp13_5.4.1.u4_mlnx
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/mlnx/
+        enabled=0
+        gpgcheck=1
+        
+        [kernel]
+        name=nuage_osp13_5.4.1.u4_kernel
+        baseurl=http://1.2.3.4/kernel/
+        enabled=0
+        gpgcheck=1
+        
+        [extra]
+        name=satellite
+        baseurl=http://1.2.3.4/extra_repo
+        enabled=1
+        gpgcheck=1
+    
+    b. Configure nuage_patching_config.yaml like:
 
-`python nuage_overcloud_full_patch.py --RhelUserName='<value>' --RhelPassword='<value>' --RhelPool=<pool-id> --RepoName=<value> --RepoBaseUrl=http://IP/reponame --AVRSBaseUrl=http://IP/reponame --ImageName='<value>' --Version=13 --no-signing-key`
+        ImageName: "overcloud-full.qcow2"
+        DeploymentType: ["ovrs"]
+        RpmPublicKey: ['RPM-GPG-Nuage-key', 'RPM-GPG-SOMEOTHER-key']
+        RepoFile: './nuage_ospd13.repo'
+        VRSRepoNames: ['nuage_vrs']
+        MellanoxRepoNames: ['mlnx']
+        KernelRepoNames: ['kernel']
+        KernelHF: True
+        logFileName: "nuage_image_patching.log"
+    
+    c. Run: python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
+    
+2.2 Using different repos for nuage & kernel & mellanox packages and with Redhat Subscription for dependent packages:
 
-This script takes in following input parameters:   
-  * RhelUserName is the user name for the RedHat Enterprise Linux subscription.
-  * RhelPassword is the password for the RedHat Enterprise Linux subscription
-  * RepoName is the name of the local repository hosting the Nuage RPMs.
-  * RepoBaseUrl is the base URL for the repository hosting the Nuage RPMs (such as http://IP/reponame)
-  * AVRSBaseUrl is the base URL for the repository hosting the 6Wind and AVRS RPMs (such as http://IP/reponame)
-  * RhelPool is the RedHat Enterprise Linux pool to which the base packages are subscribed. instructions to get this can be found [here](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html/director_installation_and_usage/installing-the-undercloud#registering-and-updating-your-undercloud) in the 2nd point.
-  * ImageName is the name of the qcow2 image (for example, overcloud-full.qcow2)
-  * Version is the OpenStack Platform director version (for Queens, the version is 13).
-  * RpmPublicKey is the GPG-Key file name (repeat option to set multiple RPM GPG Keys).
-  * no-signing-key is 'Image patching proceeds with package signature verification disabled'
-  * logFile is to pass log file name
+    a. I have configured four different repos like following in my nuage_ospd13.repo:
+        
+        [nuage]
+        name=nuage_osp13_5.4.1.u4_nuage
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_extra
+        enabled=1
+        gpgcheck=1 
+               
+        [nuage_vrs]
+        name=nuage_osp13_5.4.1.u4_nuage_ovrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_vrs
+        enabled=0
+        gpgcheck=1
+                
+        [mlnx]
+        name=nuage_osp13_5.4.1.u4_mlnx
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/mlnx/
+        enabled=0
+        gpgcheck=1
+        
+        [kernel]
+        name=nuage_osp13_5.4.1.u4_kernel
+        baseurl=http://1.2.3.4/kernel/
+        enabled=0
+        gpgcheck=1
+        
+        [extra]
+        name=satellite
+        baseurl=http://1.2.3.4/extra_repo
+        enabled=1
+        gpgcheck=1
+    
+    b. Configure nuage_patching_config.yaml like:
+
+        ImageName: "overcloud-full.qcow2"
+        DeploymentType: ["ovrs"]
+        RhelUserName: 'abc'
+        RhelPassword: '***'
+        RhelPool: '1234567890123445'
+        RpmPublicKey: ['RPM-GPG-Nuage-key', 'RPM-GPG-SOMEOTHER-key']
+        RepoFile: './nuage_ospd13.repo'
+        VRSRepoNames: ['nuage_vrs']
+        MellanoxRepoNames: ['mlnx']
+        KernelRepoNames: ['kernel']
+        KernelHF: True
+        logFileName: "nuage_image_patching.log"
+    
+    c. Run: python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
+
+2.2 Using different repos for nuage and same repo for kernel mellanox packages and No Redhat Subscription for dependent packages:
+
+    a. I have configured four different repos like following in my nuage_ospd13.repo:
+        
+        [nuage]
+        name=nuage_osp13_5.4.1.u4_nuage
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_extra
+        enabled=1
+        gpgcheck=1 
+               
+        [nuage_vrs]
+        name=nuage_osp13_5.4.1.u4_nuage_ovrs
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/nuage_vrs
+        enabled=0
+        gpgcheck=1
+                
+        [mlnx_kernel]
+        name=nuage_osp13_5.4.1.u4_mlnx
+        baseurl=http://1.2.3.4/nuage_osp13_5.4.1/mlnx_kernel/
+        enabled=0
+        gpgcheck=1
+                
+        [extra]
+        name=satellite
+        baseurl=http://1.2.3.4/extra_repo
+        enabled=1
+        gpgcheck=1
+    
+    b. Configure nuage_patching_config.yaml like:
+
+        ImageName: "overcloud-full.qcow2"
+        DeploymentType: ["ovrs"]
+        RpmPublicKey: ['RPM-GPG-Nuage-key', 'RPM-GPG-SOMEOTHER-key']
+        RepoFile: './nuage_ospd13.repo'
+        VRSRepoNames: ['nuage_vrs']
+        MellanoxRepoNames: ['mlnx_kernel']
+        KernelRepoNames: ['mlnx_kernel']
+        KernelHF: True
+        logFileName: "nuage_image_patching.log"
+    
+    c. Run: python nuage_overcloud_full_patch.py --nuage-config nuage_patching_config.yaml
 
 If image patching fails for some reason then remove the partially patched overcloud-full.qcow2 and create a copy of it from backup image before retrying image patching again.   
 
-```
-rm overcloud-full.qcow2
-cp overcloud-full-bk.qcow2 overcloud-full.qcow2
-```
+    rm overcloud-full.qcow2
+    cp overcloud-full-bk.qcow2 overcloud-full.qcow2
+
 
 Once the patching is done successfully copy back the patched image to /home/stack/images/ on undercloud-director   
 
@@ -94,7 +364,8 @@ Run the below commands:
 +--------------------------------------+------------------------+
 ```
 
-then run the below commad   
+then run the below command   
+
 ```
 (undercloud) [stack@director images]$ openstack overcloud image upload --update-existing --image-path /home/stack/images/
 (undercloud) [stack@director images]$ openstack overcloud node configure $(openstack baremetal node list -c UUID -f value)

--- a/image-patching/stopgap-script/nuage_ospd13.repo.sample
+++ b/image-patching/stopgap-script/nuage_ospd13.repo.sample
@@ -1,0 +1,73 @@
+########################################################################################################################
+############## Repositories which user want to enable by default on the overcloud image while patching #################
+########################################################################################################################
+
+# This repo should contain following packages:
+# nuage-puppet-modules
+# selinux-policy-nuage
+# nuage-bgp
+# nuage-openstack-neutronclient
+[nuage]
+name=nuage_osp13_5.4.1.u4_nuage
+baseurl=http://<HOST-IP-HOSTING-REPOS>/nuage_osp13_5.4.1/nuage_extra
+enabled=1
+gpgcheck=1
+
+# These are some placeholder for some other repos that user want to enable these packages.
+# This repo should contain following packages:
+# libvirt
+# perl-JSON
+# lldpad
+# libguestfs-tools etc...
+[extra]
+name=satellite
+baseurl=http://satellite.com/extra_repo
+enabled=1
+gpgcheck=1
+
+
+########################################################################################################################
+############## Repositories which we recommend user to disable by default ##############################################
+########################################################################################################################
+
+# This repo should contain following packages:
+# nuage-openvswitch
+# nuage-metadata
+[nuage_vrs]
+name=nuage_osp13_5.4.1.u4_nuage
+baseurl=http://<HOST-IP-HOSTING-REPOS>/nuage_osp13_5.4.1/nuage_vrs
+enabled=1
+gpgcheck=1
+
+# This repo should contain following packages (Kernel HF provided by Redhat):
+# kernel
+# kernel-tools
+# kernel-tools-libs
+# python-perf
+[kernel]
+name=satellite1
+baseurl=http://<HOST-IP-HOSTING-REPOS>/repo
+enabled=0
+gpgcheck=1
+
+# kmod-mlnx-en
+# mlnx-en-utils
+# mstflint
+# os-net-config
+# Note: This is only required for OVRS Deployment.
+[mlnx]
+name=satellite2
+baseurl=http://<HOST-IP-HOSTING-REPOS>/repo
+enabled=0
+gpgcheck=1
+
+# This repo should contain following packages:
+# nuage-openvswitch
+# nuage-metadata
+# 6wind packages
+# Note: This is only required for AVRS Deployment
+[nuage_avrs]
+name=nuage_osp13_5.4.1.u4_avrs
+baseurl=http://<HOST-IP-HOSTING-REPOS>/nuage_osp13_5.4.1/avrs
+enabled=0
+gpgcheck=1

--- a/image-patching/stopgap-script/nuage_patching_config.yaml
+++ b/image-patching/stopgap-script/nuage_patching_config.yaml
@@ -19,7 +19,7 @@ RhelUserName: ''
 # optional
 RhelPassword: ''
 
-#Pool to subscribe to for base packages
+# Pool to subscribe to for base packages
 # type: string
 # optional
 RhelPool: ''
@@ -27,11 +27,13 @@ RhelPool: ''
 # RPM GPG Key
 # type: list
 # optional
+# Note: Make sure to copy GPG-Key file(s) to the same folder as "nuage_overcloud_full_patch.py"
 RpmPublicKey: []
 
 # Path for the Repo File
 # type: string
 # required
+# Note: Make sure to place repo file in the same folder as "nuage_overcloud_full_patch.py"
 RepoFile: ''
 
 # Name for the repo hosting the Nuage O/VRS RPMs

--- a/image-patching/stopgap-script/nuage_patching_config.yaml
+++ b/image-patching/stopgap-script/nuage_patching_config.yaml
@@ -1,0 +1,77 @@
+# Name of the qcow2 image
+# type: string
+# required
+ImageName: "overcloud-full.qcow2"
+
+# DeploymentType for your Deployment
+# type: string
+# required ( Please choose one of them )
+# Eg:  ["ovrs"] or ["avrs"]
+DeploymentType: []
+
+# User name for RHEL Subscription
+# type: string
+# optional
+RhelUserName: ''
+
+# Password for the RHEL Subscription 
+# type: string
+# optional
+RhelPassword: ''
+
+#Pool to subscribe to for base packages
+# type: string
+# optional
+RhelPool: ''
+
+# RPM GPG Key
+# type: list
+# optional
+RpmPublicKey: []
+
+# Path for the Repo File
+# type: string
+# required
+RepoFile: ''
+
+# Name for the repo hosting the Nuage O/VRS RPMs
+# type:  list
+# required
+# Eg:  ["vrs_repo_name1", "vrs_repo_name2"]
+VRSRepoNames: []
+
+# Name for the repo hosting the Nuage AVRS RPMs 
+# type: list
+# optional
+# Eg:  ["avrs_repo_name1", "avrs_repo_name2"]
+AVRSRepoNames: []
+
+# Name for the repo hosting the Mellanox and os-net-config RPMs
+# type: list
+# optional
+# Eg:  ["mlnx_repo_name1", "mlnx_repo_name2"]
+MellanoxRepoNames: []
+
+# Name for the repo hosting the Kernel RPMs
+# type: list
+# optional
+# Eg:  ["rh_kernel_repo_name1", "rh_kernel_repo_name2"]
+KernelRepoNames: []
+
+# To install Kernel Hot Fix or not and defaults to False.
+# When this is set to True, KernelRepoNames can't be empty.
+# type: boolean
+# optional
+# Eg: KernelHF: True
+KernelHF: False
+
+# Log file name
+# type: string
+# optional
+logFileName: "nuage_image_patching.log"
+
+# If you are behind Proxy you can enter Proxy Server information here
+# type: string
+# optional
+ProxyHostname: ''
+ProxyPort: ''


### PR DESCRIPTION
- Now patching accepts the nuage_patching_config.yaml
- Same script can be used for VRS/AVRS/OVRS patching
- Whole patching is done by calling virt-customize only once instead of many.
- Patching script accepts single repo file, which can have multiple repositories.
- if there are any missing packages while installing, patching script will detect it and stop/fail.
- For OVRS, copying of os-net-config scripts is removed and support for installing hot fix os-net-config is added.