### PR TITLE
Fixing Patching script

### DIFF
--- a/image-patching/stopgap-script/README.md
+++ b/image-patching/stopgap-script/README.md
@@ -26,7 +26,7 @@ Copy the `overcloud-full.qcow2` from undercloud-director /home/stack/images/ to 
 This script takes in `nuage_patching_config.yaml` as input parameters:  Please configure the following parameters. 
   
   * ImageName(required) is the name of the qcow2 image (for example, overcloud-full.qcow2)
-  * DeploymentType(required) is for user to specify which deployment is it. Please choose from "ovrs" or "avrs"
+  * DeploymentType(required) is for user to specify which deployment is it. Please choose from "vrs" or "ovrs" or "avrs"
         
         Note: Currently Nuage doesn't support both AVRS and OVRS deployment together
   * RhelUserName(optional) is the user name for the RedHat Enterprise Linux subscription.
@@ -350,10 +350,6 @@ If image patching fails for some reason then remove the partially patched overcl
     cp overcloud-full-bk.qcow2 overcloud-full.qcow2
 
 
-The image patching script uses libguestfs virt-customize function, which adds the machine-id to the overcloud-full.qcow2 resulting in all the overcloud nodes to have the same machine-id. The following command needs to be applied once the patching is done successfully to remove the machine-id from the overcloud-full.qcow2.
- 	
-    virt-sysprep --operation machine-id -a overcloud-full.qcow2
- 
 In order to verify that  machine-id is clear in the overcloud image, run the following command and you should see empty output:
 
 	guestfish -a overcloud-full.qcow2 run : mount /dev/sda / : cat /etc/machine-id 

--- a/image-patching/stopgap-script/nuage_patching_config.yaml
+++ b/image-patching/stopgap-script/nuage_patching_config.yaml
@@ -6,8 +6,11 @@ ImageName: "overcloud-full.qcow2"
 # DeploymentType for your Deployment
 # type: string
 # required ( Please choose one of them )
-# Eg:  ["ovrs"] or ["avrs"]
-DeploymentType: []
+# Eg:  ["ovrs"] --> OVRS deployment
+#      ["avrs"] --> AVRS + VRS deployment
+#      ["vrs"]  --> VRS deployment
+DeploymentType: ["vrs"]
+
 
 # User name for RHEL Subscription
 # type: string


### PR DESCRIPTION
OPENSTACK-2667:  script hangs forever when invalid image is provided
OPENSTACK-2668:  script should validate duplicate options provided in
                 the yaml file.
OPENSTACK-2669:  script does not validate the values provided in the
                 'DeploymentType' in the config file , instead succeeds.
OPENSTACK-2670:  script should log what values are being used in patching
                 the image
OPENSTACK-2671:  script does not catch the exceptions
                 properly when the user does not provide
                 proper yaml file
PROD-10552: Automate reset of machine-id before uploading overcloud image 