### PR TITLE
Remove OFED for 6.0.3

### DIFF
--- a/image-patching/stopgap-script/README.md
+++ b/image-patching/stopgap-script/README.md
@@ -63,10 +63,7 @@ This script takes in `nuage_patching_config.yaml` as input parameters:  Please c
             python-perf 
         
         [mlnx repo] should have all the packages that are provided by Mellanox.
-            kmod-mlnx-en
-            mlnx-en-utils
             mstflint  
-            os-net-config
         
         [nuage_avrs] should have all the packages provided by Nuage for openvswitch and 6wind rpms.
             nuage-openvswitch 

--- a/image-patching/stopgap-script/nuage_ospd13.repo.sample
+++ b/image-patching/stopgap-script/nuage_ospd13.repo.sample
@@ -50,10 +50,7 @@ baseurl=http://<HOST-IP-HOSTING-REPOS>/repo
 enabled=0
 gpgcheck=1
 
-# kmod-mlnx-en
-# mlnx-en-utils
 # mstflint
-# os-net-config
 # Note: This is only required for OVRS Deployment.
 [mlnx]
 name=satellite2

--- a/image-patching/stopgap-script/nuage_overcloud_full_patch.py
+++ b/image-patching/stopgap-script/nuage_overcloud_full_patch.py
@@ -52,7 +52,7 @@ NUAGE_PACKAGES = "nuage-puppet-modules selinux-policy-nuage " \
                  "nuage-bgp nuage-openstack-neutronclient"
 NUAGE_DEPENDENCIES = "libvirt perl-JSON lldpad"
 NUAGE_VRS_PACKAGE = "nuage-openvswitch nuage-metadata-agent"
-MLNX_OFED_PACKAGES = "kmod-mlnx-en mlnx-en-utils mstflint os-net-config"
+MLNX_OFED_PACKAGES = "mstflint"
 KERNEL_PACKAGES = "kernel kernel-tools kernel-tools-libs python-perf"
 VIRT_CUSTOMIZE_MEMSIZE = "2048"
 VIRT_CUSTOMIZE_ENV = "export LIBGUESTFS_BACKEND=direct;"
@@ -246,7 +246,6 @@ def install_mellanox(mellanox_repos):
 %s
 yum clean all
 yum install --setopt=skip_missing_names_on_install=False -y %s
-systemctl disable mlnx-en.d
 %s
 ''' % (enable_repos_cmd, MLNX_OFED_PACKAGES, disable_repos_cmd)
     write_to_file(SCRIPT_NAME, cmds)


### PR DESCRIPTION
Don't install OFED packages not needed for 6.0.3 anymore.
This PR is not production ready, it is meant to show what changes are needed e.g. documentation only mentions 5.4