### PR TITLE
Make isolcpus consistent

### DIFF
--- a/nuage-tripleo-heat-templates/environments/compute-avrs-environment.yaml
+++ b/nuage-tripleo-heat-templates/environments/compute-avrs-environment.yaml
@@ -12,7 +12,7 @@ parameter_defaults:
   # so place your most restrictive filters first to make the filtering process more efficient.
   NovaSchedulerDefaultFilters: "RetryFilter,AvailabilityZoneFilter,RamFilter,ComputeFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,ServerGroupAntiAffinityFilter,ServerGroupAffinityFilter,PciPassthroughFilter,NUMATopologyFilter,AggregateInstanceExtraSpecsFilter"
   ComputeAvrsParameters:
-    KernelArgs: "default_hugepagesz=1G hugepagesz=1G hugepages=64 iommu=pt intel_iommu=on isolcpus=1-7"
+    KernelArgs: "default_hugepagesz=1G hugepagesz=1G hugepages=64 iommu=pt intel_iommu=on isolcpus=1-7,9-15"
     NovaVcpuPinSet: "2-7,10-15"
     FastPathNics: "0000:06:00.1 0000:06:00.2"
     FastPathMask: "1,9"


### PR DESCRIPTION
I think both sets of CPUs should be excluded from being used by the Linux kernel?