### PR TITLE
fix isolcpus

### DIFF
--- a/nuage-tripleo-heat-templates/environments/compute-avrs-multirole-environment.yaml
+++ b/nuage-tripleo-heat-templates/environments/compute-avrs-multirole-environment.yaml
@@ -27,7 +27,7 @@ parameter_defaults:
     FastPathOffload: "off"
 
   ComputeAvrsDualParameters:
-    KernelArgs: "default_hugepagesz=1G hugepagesz=1G hugepages=64 iommu=pt intel_iommu=on isolcpus=1-7"
+    KernelArgs: "default_hugepagesz=1G hugepagesz=1G hugepages=64 iommu=pt intel_iommu=on isolcpus=1-7,9-15"
     NovaVcpuPinSet: "2-7,10-15"
     FastPathNics: "0000:06:00.1 0000:06:00.2"
     FastPathMask: "1,9"


### PR DESCRIPTION
This is a key difference between single and dual.

I'm wondering about CPU #0 - doesn't FastPathDPVI assign that to process special packets, and shouldn't it be excluded as well?