### PR TITLE
Note about 'latest' RHEL 7 release

### DIFF
--- a/Documentation/6.0/README.rst
+++ b/Documentation/6.0/README.rst
@@ -63,7 +63,7 @@ The workflow to integrate Nuage VSP with OpenStack Platform Director includes th
 
 * **Phase 1: Install Red Hat OpenStack Platform Director**
 
-  In this phase, you install Director on the Undercloud system by following the process in the Red Hat documentation.
+  In this phase, you install Director on the Undercloud system by following the process in the Red Hat documentation. RedHat recommends to install the latest RHEL 7 release, which may be different from the one that was used for validation by Nuage at the time of writing.
 
 * **Phase 2: Download Nuage Source Code**
 


### PR DESCRIPTION
6.0.7 was validated using RHEL 7.7, but the latest is 7.8 and there are open bug reports like https://bugzilla.redhat.com/show_bug.cgi?id=1819764 (which I hit too)

It may be better to suggest a specific RHEL release to use, i.e. the one we used for validation